### PR TITLE
changed highlighting colours so highlighted text shows up

### DIFF
--- a/nordic.theme.css
+++ b/nordic.theme.css
@@ -74,6 +74,11 @@
   --category-fade-background-hover: rgba(143, 188, 187, 0.95);
 }
 
+::selection {
+  color: #d8dee9;
+  background: #7da8a8;
+}
+
 .theme-dark {
   --header-primary: var(--nord-light3);
   --header-secondary: #a6b0bf;


### PR DESCRIPTION
In the original version, no special highlighting colour was defined, which made it impossible to see what was and was not highlighted. This commit fixes said issue.